### PR TITLE
Fix crash shortcut behavior

### DIFF
--- a/Code/Tools/W3DView/MainFrm.cpp
+++ b/Code/Tools/W3DView/MainFrm.cpp
@@ -3015,10 +3015,10 @@ CMainFrame::OnCmdMsg
 void
 CMainFrame::OnCrashApp (void)
 {
-	// Usefull HACK to get the program to crash when needed...
-	LPTSTR hack = 0;
-	(*hack) = 0;
-	return ;
+       // Previously this command intentionally crashed the application.
+       // Display a message instead to avoid accidental crashes.
+       ::AfxMessageBox(_T("CrashApp debug command triggered."), MB_OK | MB_ICONWARNING);
+       return ;
 }
 
 


### PR DESCRIPTION
## Summary
- remove the intentional crash from `OnCrashApp`
- show a warning dialog when the crash command is invoked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685583353d5c8320b85f9eefddec1847